### PR TITLE
Edits 17 January 2015

### DIFF
--- a/Hospital Graphs Monthly 2 October 2014.R
+++ b/Hospital Graphs Monthly 2 October 2014.R
@@ -59,7 +59,7 @@ levels(df2$MeasureType)
 ShortNames <- sapply(df2$MeasureName,short_name)
 df2$ShortNames <- as.factor(ShortNames)
 
-#remove the measures Pct VTE prophylaxis and overall PRO measure?
+#keep only rows with complete cases
 df2 <- df2[complete.cases(df2$ShortNames),]
 
 # #Test of subsettting by hospital name
@@ -70,6 +70,7 @@ newdir <- paste0("Extranet graphs by Hospital_",format(Sys.time(),"%Y-%m-%d-%H-%
 dir.create(paste0(getwd(),"/",newdir))
 
 #loop through the hospitals
+#KL 17 Jan 2015 need to define a short name for each of the hospital series to label the files correctly
 
 for(i in 1:length(AbbrevName)){
   df2_team <- droplevels(df2[df2$AbbrevName == AbbrevName[i],])

--- a/functions.R
+++ b/functions.R
@@ -53,7 +53,8 @@ clean_up_df <- function(df=df1){
   #call after 7:8 trans to numeric
   df$Value1<-vclean_big(df$Value1)
   #switched $seriesName from TeamName
-  df$SeriesName<-vname_maker(df$TeamName,df$SeriesName)
+  #KL 17 Jan 2015 looks like the output from vname_maker is a character vector, so have to force df$SeriesName back to factor
+  df$SeriesName<-as.factor(vname_maker(df$TeamName,df$SeriesName))
   
   df$TimePeriod <- as.Date(df$TimePeriod,"%m/%d/%Y")
   


### PR DESCRIPTION
Hi Bill, I can't reproduce the blank TeamName issue.  In the clean_up_df function,  I fixed one function call, to force the df$SeriesName to be a factor after the concatenation function runs.    The main script appears to run correctly to line 72.  What happens next in the script:  (a) set up a name to attach to a file for each SeriesName.  (b) create the graphs for each hospital (c) write the graphs to files identified by the SeriesName.    HOWEVER:  the SeriesName records are TOO MANY CHARACTERS for a file names in Windows.    So you will need to come up with a look up table for the names.     By the way, there is still an error in names, Women's Hosptial vs Women's Hospital that needs correcting, you should modify the clean_up_df function to fix this problem.    Here's a handy command:   levels(df$X) will print out the levels of a factor df$X, then you can check for any remaining spelling issues, etc.
